### PR TITLE
Adjust correct guessing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /opt/app/server
 COPY server/ ./
 
 ARG APP_NAME=drawit
-ARG APP_VSN=0.1.0
+ARG APP_VSN=2.3.0
 ARG MIX_ENV=prod
 
 ENV MIX_ENV=${MIX_ENV} \

--- a/server/apps/draw_it/lib/draw_it/game_server.ex
+++ b/server/apps/draw_it/lib/draw_it/game_server.ex
@@ -269,7 +269,10 @@ defmodule DrawIt.GameServer do
   end
 
   defp correct_guess?(guess, word) do
+    word = String.downcase(word)
+
     guess
+    |> String.downcase()
     |> String.contains?(word)
   end
 end

--- a/server/apps/draw_it/lib/draw_it/game_server.ex
+++ b/server/apps/draw_it/lib/draw_it/game_server.ex
@@ -190,7 +190,7 @@ defmodule DrawIt.GameServer do
     set_logger_metadata(state)
     Logger.info("Guess", correct_word: current_round.word, guess: guess, player_id: player.id)
 
-    correct? = guess == current_round.word
+    correct? = correct_guess?(guess, current_round.word)
     already_guessed? = player.id in state.player_ids_correct_guess
 
     if !already_guessed? && correct? do
@@ -266,5 +266,10 @@ defmodule DrawIt.GameServer do
       |> Enum.random()
 
     {drawer, [drawer | drawn]}
+  end
+
+  defp correct_guess?(guess, word) do
+    guess
+    |> String.contains?(word)
   end
 end

--- a/server/apps/draw_it/mix.exs
+++ b/server/apps/draw_it/mix.exs
@@ -4,7 +4,7 @@ defmodule DrawIt.MixProject do
   def project do
     [
       app: :draw_it,
-      version: "0.1.0",
+      version: "2.3.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/server/apps/draw_it/test/draw_it/game_server_test.exs
+++ b/server/apps/draw_it/test/draw_it/game_server_test.exs
@@ -218,6 +218,19 @@ defmodule DrawIt.GameServerTest do
                })
     end
 
+    test "returns true if guess doesn't match casing", %{
+      game: game,
+      current_player: current_player
+    } do
+      {:ok, round} = GameServer.start_round(game.join_code, %{})
+
+      assert {:ok, true} =
+               GameServer.guess(game.join_code, %{
+                 player: current_player,
+                 guess: String.upcase(round.word)
+               })
+    end
+
     test "returns false if round hasn't started", %{game: game, current_player: current_player} do
       assert {:ok, false} =
                GameServer.guess(game.join_code, %{

--- a/server/apps/draw_it/test/draw_it/game_server_test.exs
+++ b/server/apps/draw_it/test/draw_it/game_server_test.exs
@@ -205,6 +205,19 @@ defmodule DrawIt.GameServerTest do
                })
     end
 
+    test "returns true if guess is substring of round's word", %{
+      game: game,
+      current_player: current_player
+    } do
+      {:ok, round} = GameServer.start_round(game.join_code, %{})
+
+      assert {:ok, true} =
+               GameServer.guess(game.join_code, %{
+                 player: current_player,
+                 guess: "is the word #{round.word}?"
+               })
+    end
+
     test "returns false if round hasn't started", %{game: game, current_player: current_player} do
       assert {:ok, false} =
                GameServer.guess(game.join_code, %{

--- a/server/apps/draw_it_web/mix.exs
+++ b/server/apps/draw_it_web/mix.exs
@@ -4,7 +4,7 @@ defmodule DrawItWeb.MixProject do
   def project do
     [
       app: :draw_it_web,
-      version: "0.1.0",
+      version: "2.3.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",


### PR DESCRIPTION
closes #148 

- match substrings (`'i think it's bee'` = `'bee'`)
- ignore casing (`'bee'` = `'bEE'` = `'BEE'`)