### PR TITLE
Set MIX_ENV=test in backend tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  MIX_ENV: test
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/server/mix.exs
+++ b/server/mix.exs
@@ -33,7 +33,7 @@ defmodule DrawIt.Umbrella.MixProject do
     [
       {:mix_test_watch, "~> 1.0", only: :dev, runtime: false},
       {:credo, "~> 1.4", only: [:dev, :test], runtime: false},
-      {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
+      {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:distillery, "~> 2.1"}
     ]
   end


### PR DESCRIPTION
This should speed up ci tests since the build will always be for `test` now.